### PR TITLE
README and spacing issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 **Author:** Matthew Holder
 **Version:** 0.1.0
 
-[PR]()
+[PR](https://github.com/holdermatthew5/web-scraper/pull/1#issue-566586551)
 
 Problem Domain:
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+**Author:** Matthew Holder
+**Version:** 0.1.0
+
+[PR]()
+
+Problem Domain:
+
+I would like a scraper that finds the passages that need citations added and counts how many are needed across the page.
+
+Description:
+
+get_citations_needed_count:
+- Returns an integer describing the number of citations this page needs.
+get_citations_needed_report:
+- Returns a string with every passage needing a citation on a new line.

--- a/scraper.py
+++ b/scraper.py
@@ -20,7 +20,10 @@ def get_citations_needed_report(url):
     passages = ''
     for i in range(len(p_tags)):
         if p_tags[i].find('sup', class_='noprint'):
-            passages = f'{passages}\n{p_tags[i]}'
+            if passages == '':
+                passages = f'{p_tags[i]}'
+            else:
+                passages = f'{passages}\n{p_tags[i]}'
     return passages
 
 if __name__ == '__main__':


### PR DESCRIPTION
README filled out and report return string starts with a passage instead of a space.